### PR TITLE
fix: workflow breaks when non-existent files are ignored

### DIFF
--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -13,7 +13,7 @@ fi
 
 echo -e "\033[34mRemoving ignored files\033[0m" && \
 mkdir -p "$_OSSUTIL_BACKUP_DIR" && \
-mv $IGNORED_PATTERNS "$_OSSUTIL_BACKUP_DIR/" && \
+(mv $IGNORED_PATTERNS "$_OSSUTIL_BACKUP_DIR/" || true) && \
 echo -e "\033[34mUploading files\033[0m" && \
 "$_OSSUTIL" cp \
     --config-file="$_OSSUTIL_CONFIG_FILE" \


### PR DESCRIPTION
This pull request fixes #5 . It now simply ignores errors of `mv` command.